### PR TITLE
Add setup and usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,30 @@ https://github.com/user-attachments/assets/bd4efde2-9323-4db1-896c-6407263e458e
 https://github.com/user-attachments/assets/2a0478de-6e1f-4676-b778-9709b9e3f18f
 
 https://github.com/user-attachments/assets/c6d9a53d-f6c2-4924-9286-728e21b92ee8
+
+## Installation
+
+1. Install [Wally](https://github.com/UpliftGames/wally) and [Rojo](https://github.com/rojo-rbx/rojo) and make sure they are available on your `PATH`.
+2. From the repository root run `wally install` to fetch Lua dependencies.
+3. Build the place with `rojo build default.project.json -o Wallstick.rbxlx` or start a live session with `rojo serve`.
+
+## Demo
+
+A ready made place can be found at `demo/playground.rbxl`. You can open this file directly in Roblox Studio after running `wally install`. Alternatively build your own place with Rojo using the command above.
+
+## New Features
+
+* **R6 avatar support** – both R6 and R15 characters are handled correctly.
+* **Simple replication** – player orientation is replicated between clients via `Wallstick.Replication`.
+* **Runtime streaming check** – the client warns when `StreamingEnabled` is on.
+
+## Limitations
+
+* StreamingEnabled must be turned off. The system is not designed for streaming-enabled places.
+* Replication only synchronizes wall stick offsets; complex movement or physics may still look different per client.
+
+## Troubleshooting
+
+* Ensure `workspace.Terrain` exists and contains solid terrain or ground parts. The character defaults to sticking to terrain when no other part is found.
+* If the character does not attach, verify that Wally packages are installed and that Rojo successfully built the place.
+


### PR DESCRIPTION
## Summary
- document installing Wally/Rojo
- explain how to build and run the demo
- list new features (replication, R6 support)
- mention streaming limitation and troubleshooting tips

## Testing
- `wally install` *(fails: Network is unreachable)*
- `rojo build default.project.json -o build.rbxlx`


------
https://chatgpt.com/codex/tasks/task_e_686bf6b269708325a47bc730340dea41