### PR TITLE
Fix player death when falling off

### DIFF
--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -277,7 +277,14 @@ end
 
 function WallstickClass._stepPhysics(self: Wallstick, _dt: number)
 	if self.fake.rootPart.Position.Y <= workspace.FallenPartsDestroyHeight then
-		self:Destroy()
+		if self.real.humanoid.Health > 0 then
+			self.real.humanoid.Health = 0
+
+			task.spawn(function()
+				self.real.humanoid.Died:Wait()
+				self:Destroy()
+			end)
+		end
 		return
 	end
 


### PR DESCRIPTION
## Summary
- ensure the wallstick controller kills the player when the fake character falls beneath `FallenPartsDestroyHeight`
- clean up the controller after the character dies

## Testing
- `npx stylua src/client/Wallstick/init.luau` *(fails: Not Found - GET https://registry.npmjs.org/stylua)*

------
https://chatgpt.com/codex/tasks/task_e_686bf93b04f08325863e6ea56c99a256