### PR TITLE
Add CI test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Wally
+        run: |
+          curl -L https://github.com/UpliftGames/wally/releases/download/v0.3.2/wally-v0.3.2-linux.zip -o wally.zip
+          unzip -q wally.zip -d wally
+          sudo mv wally/wally-linux /usr/local/bin/wally
+          chmod +x /usr/local/bin/wally
+      - name: Install Rojo
+        run: |
+          curl -L https://github.com/rojo-rbx/rojo/releases/download/v7.5.1/rojo-7.5.1-linux-x86_64.zip -o rojo.zip
+          unzip -q rojo.zip -d rojo
+          sudo mv rojo/rojo-7.5.1-linux-x86_64 /usr/local/bin/rojo
+          chmod +x /usr/local/bin/rojo
+      - name: Install Lune
+        run: |
+          curl -L https://github.com/lune-org/lune/releases/download/v0.9.3/lune-0.9.3-linux-x86_64.zip -o lune.zip
+          unzip -q lune.zip -d lune
+          sudo mv lune/lune-0.9.3-linux-x86_64 /usr/local/bin/lune
+          chmod +x /usr/local/bin/lune
+      - name: Install dependencies
+        run: wally install
+      - name: Run tests
+        run: lune run lune/run-tests.luau


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to automatically run tests on pushes and PRs

## Testing
- `lune/run-tests.luau` *(fails: `wally: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c0cfdd70083259b875eb9af6693d2