### PR TITLE
Add caching for Wally packages in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Wally packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            Packages
+            DevPackages
+            ServerPackages
+          key: ${{ runner.os }}-wally-${{ hashFiles('wally.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-wally-
+
+      - name: Install dependencies
+        run: |
+          if [ ! -x "$(command -v wally)" ]; then
+            curl -L https://github.com/UpliftGames/wally/releases/download/v0.3.2/wally-v0.3.2-linux.zip -o wally.zip
+            unzip -q wally.zip -d wally
+            sudo mv wally/wally /usr/local/bin/wally
+          fi
+          wally --version
+          lune run lune/wally-install.luau
+
+      - name: Run tests
+        run: |
+          lune run lune/run-tests.luau


### PR DESCRIPTION
## Summary
- add workflow for running tests
- cache Wally package directories before installing dependencies

## Testing
- `wally install` *(fails: failed to connect to github.com)*
- `lune run lune/run-tests.luau` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc457543c8325b8e6d1e455e72c51