### PR TITLE
Add planetary fall recovery

### DIFF
--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -75,7 +75,18 @@ local function onCharacterAdded(character: Model)
 	local hrp = humanoid and humanoid.RootPart :: BasePart
 
 	local fallTime = 0
-	local planets = { "PlanetA", "PlanetB", "PlanetC" }
+
+	local function getPlanets()
+		local list = {}
+		for _, obj in ipairs(workspace:GetChildren()) do
+			if obj:IsA("BasePart") and obj.Name:sub(1, 6) == "Planet" then
+				table.insert(list, obj)
+			end
+		end
+		return list
+	end
+
+	local planets = getPlanets()
 	local spawnLocation = workspace:FindFirstChild("SpawnLocation")
 
 	local function findNearestPlanet()
@@ -83,15 +94,12 @@ local function onCharacterAdded(character: Model)
 		local closestDist = math.huge
 		local pos = hrp.Position
 
-		for _, name in ipairs(planets) do
-			local planet = workspace:FindFirstChild(name)
-			if planet and planet:IsA("BasePart") then
-				local dist = (planet.Position - pos).Magnitude
-				local radius = planet.Size.Magnitude * 1.5
-				if dist <= radius and dist < closestDist then
-					closest = planet
-					closestDist = dist
-				end
+		for _, planet in ipairs(planets) do
+			local dist = (planet.Position - pos).Magnitude
+			local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
+			if dist <= radius and dist < closestDist then
+				closest = planet
+				closestDist = dist
 			end
 		end
 
@@ -103,7 +111,7 @@ local function onCharacterAdded(character: Model)
 		instances = { character :: Instance },
 	})
 
-	local function findNearestSurface()
+	local function findNearestSurface(range: number, planetsOnly: boolean?)
 		local hrpCF = hrp.CFrame
 		local directions = {
 			-hrpCF.YVector,
@@ -116,14 +124,28 @@ local function onCharacterAdded(character: Model)
 
 		local best
 		for _, dir in ipairs(directions) do
-			local result = workspace:Raycast(hrp.Position, dir.Unit * Config.PULL_SEARCH_RADIUS, rayParams)
-			if result and (not best or result.Distance < best.Distance) then
-				best = result
+			local result = workspace:Raycast(hrp.Position, dir.Unit * range, rayParams)
+			if result and (not planetsOnly or result.Instance.Name:sub(1, 6) == "Planet") then
+				if not best or result.Distance < best.Distance then
+					best = result
+				end
 			end
 		end
 
 		return best
 	end
+
+	local touchedConnection = hrp.Touched:Connect(function(hit)
+		if hit.Name:sub(1, 6) == "Planet" then
+			local surface = findNearestSurface(Config.STICK_RANGE, true)
+			if surface then
+				local part = (surface.Instance :: BasePart).AssemblyRootPart
+				local normal = part.CFrame:VectorToObjectSpace(surface.Normal)
+				wallstick:setAndPivot(part, normal, surface.Position)
+				fallTime = 0
+			end
+		end
+	end)
 
 	local simulationConnection = RunService.PreSimulation:Connect(function(dt)
 		if not wallstick:isEnabled() then
@@ -182,6 +204,7 @@ local function onCharacterAdded(character: Model)
 
 	humanoid.Died:Wait()
 	simulationConnection:Disconnect()
+	touchedConnection:Disconnect()
 	wallstick:Destroy()
 end
 

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -70,92 +70,115 @@ local function onCharacterAdded(character: Model)
 		},
 	})
 
-        local humanoid = character and character:WaitForChild("Humanoid") :: Humanoid
-        humanoid.WalkSpeed = 20
-        local hrp = humanoid and humanoid.RootPart :: BasePart
+	local humanoid = character and character:WaitForChild("Humanoid") :: Humanoid
+	humanoid.WalkSpeed = 20
+	local hrp = humanoid and humanoid.RootPart :: BasePart
 
-        local fallTime = 0
+	local fallTime = 0
+	local planets = { "PlanetA", "PlanetB", "PlanetC" }
+	local spawnLocation = workspace:FindFirstChild("SpawnLocation")
+
+	local function findNearestPlanet()
+		local closest
+		local closestDist = math.huge
+		local pos = hrp.Position
+
+		for _, name in ipairs(planets) do
+			local planet = workspace:FindFirstChild(name)
+			if planet and planet:IsA("BasePart") then
+				local dist = (planet.Position - pos).Magnitude
+				local radius = planet.Size.Magnitude * 1.5
+				if dist <= radius and dist < closestDist then
+					closest = planet
+					closestDist = dist
+				end
+			end
+		end
+
+		return closest
+	end
 
 	local rayParams = RaycastHelper.params({
 		filterType = Enum.RaycastFilterType.Exclude,
 		instances = { character :: Instance },
 	})
 
-        local function findNearestSurface()
-                local hrpCF = hrp.CFrame
-                local directions = {
-                        -hrpCF.YVector,
-                        Vector3.yAxis * -1,
-                        hrpCF.LookVector,
-                        -hrpCF.LookVector,
-                        hrpCF.RightVector,
-                        -hrpCF.RightVector,
-                }
+	local function findNearestSurface()
+		local hrpCF = hrp.CFrame
+		local directions = {
+			-hrpCF.YVector,
+			Vector3.yAxis * -1,
+			hrpCF.LookVector,
+			-hrpCF.LookVector,
+			hrpCF.RightVector,
+			-hrpCF.RightVector,
+		}
 
-                local best
-                for _, dir in ipairs(directions) do
-                        local result = workspace:Raycast(
-                                hrp.Position,
-                                dir.Unit * Config.PULL_SEARCH_RADIUS,
-                                rayParams
-                        )
-                        if result and (not best or result.Distance < best.Distance) then
-                                best = result
-                        end
-                end
+		local best
+		for _, dir in ipairs(directions) do
+			local result = workspace:Raycast(hrp.Position, dir.Unit * Config.PULL_SEARCH_RADIUS, rayParams)
+			if result and (not best or result.Distance < best.Distance) then
+				best = result
+			end
+		end
 
-                return best
-        end
+		return best
+	end
 
-        local simulationConnection = RunService.PreSimulation:Connect(function(dt)
-                if not wallstick:isEnabled() then
-                        return
-                end
+	local simulationConnection = RunService.PreSimulation:Connect(function(dt)
+		if not wallstick:isEnabled() then
+			return
+		end
 
-                if wallstick:getFallDistance() < -Config.MAX_FALL_DISTANCE then
-                        wallstick:set(workspace.Terrain, Vector3.yAxis)
-                        return
-                end
+		if wallstick:getFallDistance() < -Config.MAX_FALL_DISTANCE then
+			wallstick:set(workspace.Terrain, Vector3.yAxis)
+			return
+		end
 
-                local hipHeight = humanoid.HipHeight
-                if humanoid.RigType == Enum.HumanoidRigType.R6 then
-                        hipHeight = 2
-                end
+		local hipHeight = humanoid.HipHeight
+		if humanoid.RigType == Enum.HumanoidRigType.R6 then
+			hipHeight = 2
+		end
 
-                local hrpCF = hrp.CFrame
-                local result = RaycastHelper.raycast({
-                        origin = hrpCF.Position,
-                        direction = -(hipHeight + hrp.Size.Y / 2 + Config.STICK_RANGE) * hrpCF.YVector,
-                        filter = ignoreCharacterParts,
-                        rayParams = rayParams,
-                })
+		local hrpCF = hrp.CFrame
+		local result = RaycastHelper.raycast({
+			origin = hrpCF.Position,
+			direction = -(hipHeight + hrp.Size.Y / 2 + Config.STICK_RANGE) * hrpCF.YVector,
+			filter = ignoreCharacterParts,
+			rayParams = rayParams,
+		})
 
-                if result then
-                        local stickPart = (result.Instance :: BasePart).AssemblyRootPart
-                        local stickNormal = stickPart.CFrame:VectorToObjectSpace(result.Normal)
+		if result then
+			local stickPart = (result.Instance :: BasePart).AssemblyRootPart
+			local stickNormal = stickPart.CFrame:VectorToObjectSpace(result.Normal)
 
-                        wallstick:setAndPivot(stickPart, stickNormal, result.Position)
-                        fallTime = 0
-                else
-                        if humanoid:GetState() == Enum.HumanoidStateType.Freefall then
-                                fallTime += dt
-                                if fallTime >= Config.FALL_PULL_TIME then
-                                        local surface = findNearestSurface()
-                                        if surface then
-                                                local part = (surface.Instance :: BasePart).AssemblyRootPart
-                                                local normal = part.CFrame:VectorToObjectSpace(surface.Normal)
-                                                wallstick:setAndTeleport(part, normal, surface.Position)
-                                                fallTime = 0
-                                        else
-                                                wallstick:set(workspace.Terrain, Vector3.yAxis)
-                                                fallTime = 0
-                                        end
-                                end
-                        else
-                                fallTime = 0
-                        end
-                end
-        end)
+			wallstick:setAndPivot(stickPart, stickNormal, result.Position)
+			fallTime = 0
+		else
+			if humanoid:GetState() == Enum.HumanoidStateType.Freefall then
+				fallTime += dt
+
+				if fallTime >= Config.RESPAWN_TIME then
+					if spawnLocation then
+						hrp.AssemblyLinearVelocity = Vector3.zero
+						hrp.CFrame = spawnLocation.CFrame
+							* CFrame.new(0, spawnLocation.Size.Y / 2 + humanoid.HipHeight, 0)
+						wallstick:set(workspace.Terrain, Vector3.yAxis)
+					end
+					fallTime = 0
+				elseif fallTime >= Config.PLANET_PULL_TIME then
+					local planet = findNearestPlanet()
+					if planet then
+						local direction = (planet.Position - hrp.Position).Unit
+						local speed = hrp.AssemblyLinearVelocity.Magnitude
+						hrp.AssemblyLinearVelocity = direction * speed
+					end
+				end
+			else
+				fallTime = 0
+			end
+		end
+	end)
 
 	humanoid.Died:Wait()
 	simulationConnection:Disconnect()

--- a/src/shared/WallstickConfig.luau
+++ b/src/shared/WallstickConfig.luau
@@ -8,6 +8,7 @@ local Config = {
 	PULL_SEARCH_RADIUS = 20, -- radius to search for a surface when pulling
 	PLANET_PULL_TIME = 4, -- seconds before pulling to nearest planet
 	RESPAWN_TIME = 7, -- seconds before teleporting to SpawnLocation
+	PLANET_ORBIT_MULTIPLIER = 2, -- multiplier for planet orbit radius based on size
 }
 
 return Config

--- a/src/shared/WallstickConfig.luau
+++ b/src/shared/WallstickConfig.luau
@@ -1,11 +1,13 @@
 --!strict
 
 local Config = {
-    STICK_RANGE = 6, -- studs to check downward from root
-    DETECTION_SHAPE = "Box", -- Detection shape: "Box" or "Ray"
-    MAX_FALL_DISTANCE = 50, -- studs before resetting to terrain
-    FALL_PULL_TIME = 2, -- seconds before auto reattaching in freefall
-    PULL_SEARCH_RADIUS = 20, -- radius to search for a surface when pulling
+	STICK_RANGE = 6, -- studs to check downward from root
+	DETECTION_SHAPE = "Box", -- Detection shape: "Box" or "Ray"
+	MAX_FALL_DISTANCE = 50, -- studs before resetting to terrain
+	FALL_PULL_TIME = 4, -- seconds before auto reattaching in freefall
+	PULL_SEARCH_RADIUS = 20, -- radius to search for a surface when pulling
+	PLANET_PULL_TIME = 4, -- seconds before pulling to nearest planet
+	RESPAWN_TIME = 7, -- seconds before teleporting to SpawnLocation
 }
 
 return Config


### PR DESCRIPTION
## Summary
- extend wallstick config with planet pull timings
- pull player towards nearest planet when falling too long
- reset to SpawnLocation after extended freefall

## Testing
- `stylua src/shared/WallstickConfig.luau src/client/clientEntry.client.luau`

------
https://chatgpt.com/codex/tasks/task_e_687312a3151c8325ad48577199c7f085