### PR TITLE
Refactor planet handling

### DIFF
--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -76,17 +76,30 @@ local function onCharacterAdded(character: Model)
 
 	local fallTime = 0
 
-	local function getPlanets()
-		local list = {}
-		for _, obj in ipairs(workspace:GetChildren()) do
-			if obj:IsA("BasePart") and obj.Name:sub(1, 6) == "Planet" then
-				table.insert(list, obj)
-			end
-		end
-		return list
-	end
+        local planetsFolder = workspace:FindFirstChild("Planets")
+        assert(planetsFolder, "Planets folder missing")
 
-	local planets = getPlanets()
+        local function getPlanetPart(instance: Instance): BasePart?
+                if instance:IsA("BasePart") then
+                        return instance
+                elseif instance:IsA("Model") then
+                        return instance.PrimaryPart or instance:FindFirstChildWhichIsA("BasePart")
+                end
+                return nil
+        end
+
+        local function getPlanets()
+                local list = {}
+                for _, obj in ipairs(planetsFolder:GetChildren()) do
+                        local part = getPlanetPart(obj)
+                        if part then
+                                table.insert(list, part)
+                        end
+                end
+                return list
+        end
+
+        local planets = getPlanets()
 	local spawnLocation = workspace:FindFirstChild("SpawnLocation")
 
 	local function findNearestPlanet()
@@ -123,25 +136,25 @@ local function onCharacterAdded(character: Model)
 		}
 
 		local best
-		for _, dir in ipairs(directions) do
-			local result = workspace:Raycast(hrp.Position, dir.Unit * range, rayParams)
-			if result and (not planetsOnly or result.Instance.Name:sub(1, 6) == "Planet") then
-				if not best or result.Distance < best.Distance then
-					best = result
-				end
-			end
-		end
+                for _, dir in ipairs(directions) do
+                        local result = workspace:Raycast(hrp.Position, dir.Unit * range, rayParams)
+                        if result and (not planetsOnly or result.Instance:IsDescendantOf(planetsFolder)) then
+                                if not best or result.Distance < best.Distance then
+                                        best = result
+                                end
+                        end
+                end
 
 		return best
 	end
 
-	local touchedConnection = hrp.Touched:Connect(function(hit)
-		if hit.Name:sub(1, 6) == "Planet" then
-			local surface = findNearestSurface(Config.STICK_RANGE, true)
-			if surface then
-				local part = (surface.Instance :: BasePart).AssemblyRootPart
-				local normal = part.CFrame:VectorToObjectSpace(surface.Normal)
-				wallstick:setAndPivot(part, normal, surface.Position)
+        local touchedConnection = hrp.Touched:Connect(function(hit)
+                if hit:IsDescendantOf(planetsFolder) then
+                        local surface = findNearestSurface(Config.STICK_RANGE, true)
+                        if surface then
+                                local part = (surface.Instance :: BasePart).AssemblyRootPart
+                                local normal = part.CFrame:VectorToObjectSpace(surface.Normal)
+                                wallstick:setAndPivot(part, normal, surface.Position)
 				fallTime = 0
 			end
 		end

--- a/src/server/LaunchPad.server.luau
+++ b/src/server/LaunchPad.server.luau
@@ -1,0 +1,51 @@
+--!strict
+
+local Players = game:GetService("Players")
+local Debris = game:GetService("Debris")
+
+local attributeName = "DestinationPlanet"
+local launchSpeed = 300 -- studs per second
+
+local launchPad = script.Parent
+assert(launchPad:IsA("BasePart"), "LaunchPad script must be parented to a BasePart")
+
+local planetsFolder = workspace:WaitForChild("Planets")
+
+local function getDestination(): BasePart?
+    local name = launchPad:GetAttribute(attributeName)
+    if typeof(name) == "string" then
+        local planet = planetsFolder:FindFirstChild(name)
+        if planet then
+            if planet:IsA("BasePart") then
+                return planet
+            elseif planet:IsA("Model") then
+                return planet.PrimaryPart or planet:FindFirstChildWhichIsA("BasePart")
+            end
+        end
+    end
+    return nil
+end
+
+local function onTouched(other: BasePart)
+    local character = other:FindFirstAncestorOfClass("Model")
+    if not character then return end
+
+    local humanoid = character:FindFirstChildWhichIsA("Humanoid")
+    local root = humanoid and humanoid.RootPart
+    if not root or not root:IsDescendantOf(workspace) then return end
+
+    local destination = getDestination()
+    if not destination then return end
+
+    local direction = (destination.Position - root.Position).Unit
+
+    local bodyVelocity = Instance.new("BodyVelocity")
+    bodyVelocity.Velocity = direction * launchSpeed
+    bodyVelocity.MaxForce = Vector3.new(1e5, 1e5, 1e5)
+    bodyVelocity.P = 1e4
+    bodyVelocity.Parent = root
+
+    Debris:AddItem(bodyVelocity, 1)
+end
+
+launchPad.Touched:Connect(onTouched)


### PR DESCRIPTION
## Summary
- update planet lookup to use new `workspace.Planets` folder
- check for models or parts when finding planets
- use new descendant checks when colliding with planets
- add a `LaunchPad` script for sending players from one planet to another

## Testing
- `rojo --version` *(fails: command not found)*
- `lune --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687334715c088325aab9db611c8e41f8