### PR TITLE
Add planet hop double jump

### DIFF
--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -92,6 +92,7 @@ local function onCharacterAdded(character: Model)
 
 	local lastJumpTime = 0
 	local jumpCount = 0
+	local ignoreSurfaceEnd = 0
 
 	local function findNearestPlanet(exclude: BasePart?)
 		local closest
@@ -116,6 +117,9 @@ local function onCharacterAdded(character: Model)
 		local current = wallstick:getPart()
 		local target = findNearestPlanet(current)
 		if target then
+			wallstick:set(workspace.Terrain, Vector3.yAxis)
+			ignoreSurfaceEnd = os.clock() + 0.5
+			fallTime = 0
 			local direction = (target.Position - hrp.Position).Unit
 			hrp.AssemblyLinearVelocity = direction * Config.DOUBLE_JUMP_SPEED
 		end
@@ -163,18 +167,17 @@ local function onCharacterAdded(character: Model)
 	end)
 
 	local jumpRequestConnection = UserInputService.JumpRequest:Connect(function()
-		if humanoid:GetState() == Enum.HumanoidStateType.Freefall then
-			local now = os.clock()
-			if now - lastJumpTime <= 0.4 then
-				jumpCount += 1
-			else
-				jumpCount = 1
-			end
-			lastJumpTime = now
-			if jumpCount >= 2 then
-				planetHop()
-				jumpCount = 0
-			end
+		local now = os.clock()
+		if now - lastJumpTime <= 0.4 then
+			jumpCount += 1
+		else
+			jumpCount = 1
+		end
+		lastJumpTime = now
+
+		if jumpCount >= 2 and humanoid:GetState() == Enum.HumanoidStateType.Freefall then
+			planetHop()
+			jumpCount = 0
 		end
 	end)
 
@@ -211,7 +214,7 @@ local function onCharacterAdded(character: Model)
 			rayParams = rayParams,
 		})
 
-		if result then
+		if result and os.clock() >= ignoreSurfaceEnd then
 			local stickPart = (result.Instance :: BasePart).AssemblyRootPart
 			local stickNormal = stickPart.CFrame:VectorToObjectSpace(result.Normal)
 

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -3,7 +3,6 @@
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local UserInputService = game:GetService("UserInputService")
 
 local SharedPackages = ReplicatedStorage:FindFirstChild("SharedPackages")
 if not SharedPackages then
@@ -90,39 +89,21 @@ local function onCharacterAdded(character: Model)
 	local planets = getPlanets()
 	local spawnLocation = workspace:FindFirstChild("SpawnLocation")
 
-	local lastJumpTime = 0
-	local jumpCount = 0
-	local ignoreSurfaceEnd = 0
-
-	local function findNearestPlanet(exclude: BasePart?)
+	local function findNearestPlanet()
 		local closest
 		local closestDist = math.huge
 		local pos = hrp.Position
 
 		for _, planet in ipairs(planets) do
-			if planet ~= exclude then
-				local dist = (planet.Position - pos).Magnitude
-				local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
-				if dist <= radius and dist < closestDist then
-					closest = planet
-					closestDist = dist
-				end
+			local dist = (planet.Position - pos).Magnitude
+			local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
+			if dist <= radius and dist < closestDist then
+				closest = planet
+				closestDist = dist
 			end
 		end
 
 		return closest
-	end
-
-	local function planetHop()
-		local current = wallstick:getPart()
-		local target = findNearestPlanet(current)
-		if target then
-			wallstick:set(workspace.Terrain, Vector3.yAxis)
-			ignoreSurfaceEnd = os.clock() + 0.5
-			fallTime = 0
-			local direction = (target.Position - hrp.Position).Unit
-			hrp.AssemblyLinearVelocity = direction * Config.DOUBLE_JUMP_SPEED
-		end
 	end
 
 	local rayParams = RaycastHelper.params({
@@ -166,31 +147,6 @@ local function onCharacterAdded(character: Model)
 		end
 	end)
 
-	local jumpRequestConnection = UserInputService.JumpRequest:Connect(function()
-		local now = os.clock()
-		if now - lastJumpTime <= 0.4 then
-			jumpCount += 1
-		else
-			jumpCount = 1
-		end
-		lastJumpTime = now
-
-		if jumpCount >= 2 and humanoid:GetState() == Enum.HumanoidStateType.Freefall then
-			planetHop()
-			jumpCount = 0
-		end
-	end)
-
-	local stateConnection = humanoid.StateChanged:Connect(function(_, newState)
-		if
-			newState == Enum.HumanoidStateType.Landed
-			or newState == Enum.HumanoidStateType.Running
-			or newState == Enum.HumanoidStateType.RunningNoPhysics
-		then
-			jumpCount = 0
-		end
-	end)
-
 	local simulationConnection = RunService.PreSimulation:Connect(function(dt)
 		if not wallstick:isEnabled() then
 			return
@@ -214,7 +170,7 @@ local function onCharacterAdded(character: Model)
 			rayParams = rayParams,
 		})
 
-		if result and os.clock() >= ignoreSurfaceEnd then
+		if result then
 			local stickPart = (result.Instance :: BasePart).AssemblyRootPart
 			local stickNormal = stickPart.CFrame:VectorToObjectSpace(result.Normal)
 
@@ -236,7 +192,8 @@ local function onCharacterAdded(character: Model)
 					local planet = findNearestPlanet()
 					if planet then
 						local direction = (planet.Position - hrp.Position).Unit
-						hrp.AssemblyLinearVelocity = direction * Config.DOUBLE_JUMP_SPEED
+						local speed = hrp.AssemblyLinearVelocity.Magnitude
+						hrp.AssemblyLinearVelocity = direction * speed
 					end
 				end
 			else
@@ -248,8 +205,6 @@ local function onCharacterAdded(character: Model)
 	humanoid.Died:Wait()
 	simulationConnection:Disconnect()
 	touchedConnection:Disconnect()
-	jumpRequestConnection:Disconnect()
-	stateConnection:Disconnect()
 	wallstick:Destroy()
 end
 

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -3,6 +3,7 @@
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local UserInputService = game:GetService("UserInputService")
 
 local SharedPackages = ReplicatedStorage:FindFirstChild("SharedPackages")
 if not SharedPackages then
@@ -89,21 +90,35 @@ local function onCharacterAdded(character: Model)
 	local planets = getPlanets()
 	local spawnLocation = workspace:FindFirstChild("SpawnLocation")
 
-	local function findNearestPlanet()
+	local lastJumpTime = 0
+	local jumpCount = 0
+
+	local function findNearestPlanet(exclude: BasePart?)
 		local closest
 		local closestDist = math.huge
 		local pos = hrp.Position
 
 		for _, planet in ipairs(planets) do
-			local dist = (planet.Position - pos).Magnitude
-			local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
-			if dist <= radius and dist < closestDist then
-				closest = planet
-				closestDist = dist
+			if planet ~= exclude then
+				local dist = (planet.Position - pos).Magnitude
+				local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
+				if dist <= radius and dist < closestDist then
+					closest = planet
+					closestDist = dist
+				end
 			end
 		end
 
 		return closest
+	end
+
+	local function planetHop()
+		local current = wallstick:getPart()
+		local target = findNearestPlanet(current)
+		if target then
+			local direction = (target.Position - hrp.Position).Unit
+			hrp.AssemblyLinearVelocity = direction * Config.DOUBLE_JUMP_SPEED
+		end
 	end
 
 	local rayParams = RaycastHelper.params({
@@ -144,6 +159,32 @@ local function onCharacterAdded(character: Model)
 				wallstick:setAndPivot(part, normal, surface.Position)
 				fallTime = 0
 			end
+		end
+	end)
+
+	local jumpRequestConnection = UserInputService.JumpRequest:Connect(function()
+		if humanoid:GetState() == Enum.HumanoidStateType.Freefall then
+			local now = os.clock()
+			if now - lastJumpTime <= 0.4 then
+				jumpCount += 1
+			else
+				jumpCount = 1
+			end
+			lastJumpTime = now
+			if jumpCount >= 2 then
+				planetHop()
+				jumpCount = 0
+			end
+		end
+	end)
+
+	local stateConnection = humanoid.StateChanged:Connect(function(_, newState)
+		if
+			newState == Enum.HumanoidStateType.Landed
+			or newState == Enum.HumanoidStateType.Running
+			or newState == Enum.HumanoidStateType.RunningNoPhysics
+		then
+			jumpCount = 0
 		end
 	end)
 
@@ -188,12 +229,11 @@ local function onCharacterAdded(character: Model)
 						wallstick:set(workspace.Terrain, Vector3.yAxis)
 					end
 					fallTime = 0
-				elseif fallTime >= Config.PLANET_PULL_TIME then
+				elseif fallTime >= Config.OUT_OF_BOUNDS_TIME then
 					local planet = findNearestPlanet()
 					if planet then
 						local direction = (planet.Position - hrp.Position).Unit
-						local speed = hrp.AssemblyLinearVelocity.Magnitude
-						hrp.AssemblyLinearVelocity = direction * speed
+						hrp.AssemblyLinearVelocity = direction * Config.DOUBLE_JUMP_SPEED
 					end
 				end
 			else
@@ -205,6 +245,8 @@ local function onCharacterAdded(character: Model)
 	humanoid.Died:Wait()
 	simulationConnection:Disconnect()
 	touchedConnection:Disconnect()
+	jumpRequestConnection:Disconnect()
+	stateConnection:Disconnect()
 	wallstick:Destroy()
 end
 

--- a/src/shared/WallstickConfig.luau
+++ b/src/shared/WallstickConfig.luau
@@ -9,7 +9,6 @@ local Config = {
 	PLANET_PULL_TIME = 4, -- seconds before pulling to nearest planet
 	RESPAWN_TIME = 7, -- seconds before teleporting to SpawnLocation
 	OUT_OF_BOUNDS_TIME = 5, -- seconds in freefall before redirecting to a planet
-	DOUBLE_JUMP_SPEED = 80, -- velocity applied when planet hopping
 	PLANET_ORBIT_MULTIPLIER = 2, -- multiplier for planet orbit radius based on size
 }
 

--- a/src/shared/WallstickConfig.luau
+++ b/src/shared/WallstickConfig.luau
@@ -8,6 +8,8 @@ local Config = {
 	PULL_SEARCH_RADIUS = 20, -- radius to search for a surface when pulling
 	PLANET_PULL_TIME = 4, -- seconds before pulling to nearest planet
 	RESPAWN_TIME = 7, -- seconds before teleporting to SpawnLocation
+	OUT_OF_BOUNDS_TIME = 5, -- seconds in freefall before redirecting to a planet
+	DOUBLE_JUMP_SPEED = 80, -- velocity applied when planet hopping
 	PLANET_ORBIT_MULTIPLIER = 2, -- multiplier for planet orbit radius based on size
 }
 


### PR DESCRIPTION
## Summary
- add out-of-bounds and double jump settings
- implement double jump that launches the player toward the nearest planet
- redirect players that fall for too long

## Testing
- `stylua src/shared/WallstickConfig.luau src/client/clientEntry.client.luau`

------
https://chatgpt.com/codex/tasks/task_e_68733e7ca2a08325a2bdfff4e3c29c1e