### PR TITLE
Fix missing VR transform method

### DIFF
--- a/src/server/PlayerScripts/GravityCameraModifier.luau
+++ b/src/server/PlayerScripts/GravityCameraModifier.luau
@@ -184,6 +184,18 @@ return function(PlayerModule: any)
 		return currentRotationType
 	end
 
+	-- Stub implementation for compatibility with PlayerScriptsLoader.
+	-- The default PlayerModule exposes ApplyVRTransform for VR updates.
+	-- Some versions may call this method even when VR is unused, so we
+	-- forward the call to the active camera controller if available.
+	function cameraObject:ApplyVRTransform(...)
+		if self.activeCameraController and self.activeCameraController.ApplyVRTransform then
+			return self.activeCameraController:ApplyVRTransform(...)
+		end
+		-- If no handler exists, silently do nothing.
+		return nil
+	end
+
 	function cameraObject:Update(dt: number)
 		if self.activeCameraController then
 			self.activeCameraController:UpdateMouseBehavior()


### PR DESCRIPTION
## Summary
- add stub `ApplyVRTransform` method for `GravityCamera`

## Testing
- `stylua src/server/PlayerScripts/GravityCameraModifier.luau`
- `wally install` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68741328b9d08325a9782fd361eec65c