### PR TITLE
Add double jump support

### DIFF
--- a/src/client/Wallstick/DoubleJump.luau
+++ b/src/client/Wallstick/DoubleJump.luau
@@ -13,7 +13,7 @@ function DoubleJump.setup(fakeHumanoid: Humanoid, realHumanoid: Humanoid)
 	table.insert(
 		connections,
 		fakeHumanoid.StateChanged:Connect(function(_, newState)
-			if newState == Enum.HumanoidStateType.Landed then
+			if newState == Enum.HumanoidStateType.Landed or newState == Enum.HumanoidStateType.Running then
 				canDouble = true
 			end
 		end)
@@ -24,6 +24,7 @@ function DoubleJump.setup(fakeHumanoid: Humanoid, realHumanoid: Humanoid)
 		UserInputService.JumpRequest:Connect(function()
 			local state = fakeHumanoid:GetState()
 			if (state == Enum.HumanoidStateType.Jumping or state == Enum.HumanoidStateType.Freefall) and canDouble then
+				fakeHumanoid:ChangeState(Enum.HumanoidStateType.Jumping)
 				realHumanoid.Jump = true
 				canDouble = false
 			end

--- a/src/client/Wallstick/DoubleJump.luau
+++ b/src/client/Wallstick/DoubleJump.luau
@@ -1,0 +1,40 @@
+--!strict
+
+local UserInputService = game:GetService("UserInputService")
+
+local DoubleJump = {}
+
+type Connection = RBXScriptConnection
+
+function DoubleJump.setup(fakeHumanoid: Humanoid, realHumanoid: Humanoid)
+	local canDouble = true
+	local connections: { Connection } = {}
+
+	table.insert(
+		connections,
+		fakeHumanoid.StateChanged:Connect(function(_, newState)
+			if newState == Enum.HumanoidStateType.Landed then
+				canDouble = true
+			end
+		end)
+	)
+
+	table.insert(
+		connections,
+		UserInputService.JumpRequest:Connect(function()
+			local state = fakeHumanoid:GetState()
+			if (state == Enum.HumanoidStateType.Jumping or state == Enum.HumanoidStateType.Freefall) and canDouble then
+				realHumanoid.Jump = true
+				canDouble = false
+			end
+		end)
+	)
+
+	return function()
+		for _, conn in pairs(connections) do
+			conn:Disconnect()
+		end
+	end
+end
+
+return DoubleJump

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -20,6 +20,7 @@ local Config = require(ReplicatedStorage:WaitForChild("WallstickConfig"))
 
 local WallstickClass = require(ReplicatedStorage.Wallstick)
 local Replication = require(ReplicatedStorage.Wallstick.Replication)
+local DoubleJump = require(ReplicatedStorage.Wallstick.DoubleJump)
 
 local LIMB_NAMES: { [string]: boolean } = {
 	-- R6
@@ -74,6 +75,7 @@ local function onCharacterAdded(character: Model)
 	humanoid.WalkSpeed = 20
 	local hrp = humanoid and humanoid.RootPart :: BasePart
 
+	local cleanupDoubleJump = DoubleJump.setup(wallstick.fake.humanoid, wallstick.real.humanoid)
 	local fallTime = 0
 
 	local function getPlanets()
@@ -205,6 +207,7 @@ local function onCharacterAdded(character: Model)
 	humanoid.Died:Wait()
 	simulationConnection:Disconnect()
 	touchedConnection:Disconnect()
+	cleanupDoubleJump()
 	wallstick:Destroy()
 end
 


### PR DESCRIPTION
## Summary
- enable fake player double jump with default animations
- hook up double jump logic in client entry point

## Testing
- `stylua src`
- `selene src` *(fails: Could not collect standard library)*

------
https://chatgpt.com/codex/tasks/task_e_6874184fb0588325bdb53264036319bb