### PR TITLE
Handle camera state and out-of-bounds recovery

### DIFF
--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -330,17 +330,9 @@ function WallstickClass._stepRenderCharacter(self: Wallstick, _dt: number)
 end
 
 function WallstickClass._stepPhysics(self: Wallstick, _dt: number)
-	if self.fake.rootPart.Position.Y <= workspace.FallenPartsDestroyHeight then
-		if self.real.humanoid.Health > 0 then
-			self.real.humanoid.Health = 0
-
-			task.spawn(function()
-				self.real.humanoid.Died:Wait()
-				self:Destroy()
-			end)
-		end
-		return
-	end
+        if self.fake.rootPart.Position.Y <= workspace.FallenPartsDestroyHeight then
+                return
+        end
 
 	if not self.enabled then
 		return

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -80,9 +80,12 @@ local function onCharacterAdded(character: Model)
 
 	local function getPlanets()
 		local list = {}
-		for _, obj in ipairs(workspace:GetChildren()) do
-			if obj:IsA("BasePart") and obj.Name:sub(1, 6) == "Planet" then
-				table.insert(list, obj)
+		local folder = workspace:FindFirstChild("Planets")
+		if folder then
+			for _, obj in ipairs(folder:GetChildren()) do
+				if obj:IsA("BasePart") and obj.Name:sub(1, 6) == "Planet" then
+					table.insert(list, obj)
+				end
 			end
 		end
 		return list
@@ -137,7 +140,10 @@ local function onCharacterAdded(character: Model)
 		return best
 	end
 
-	local touchedConnection = hrp.Touched:Connect(function(hit)
+	local outOfBounds = false
+	local touchedConnections = {} :: { RBXScriptConnection }
+
+	local function onPlanetTouched(_part: BasePart, hit: BasePart)
 		if hit.Name:sub(1, 6) == "Planet" then
 			local surface = findNearestSurface(Config.STICK_RANGE, true)
 			if surface then
@@ -145,11 +151,46 @@ local function onCharacterAdded(character: Model)
 				local normal = part.CFrame:VectorToObjectSpace(surface.Normal)
 				wallstick:setAndPivot(part, normal, surface.Position)
 				fallTime = 0
+
+				if outOfBounds then
+					hrp.AssemblyLinearVelocity = Vector3.zero
+					wallstick:setEnabled(true)
+					outOfBounds = false
+				end
 			end
 		end
-	end)
+	end
+
+	local function connectTouchListeners(model: Model)
+		for _, p in ipairs(model:GetDescendants()) do
+			if p:IsA("BasePart") then
+				table.insert(
+					touchedConnections,
+					p.Touched:Connect(function(hit)
+						onPlanetTouched(p, hit)
+					end)
+				)
+			end
+		end
+	end
+
+	connectTouchListeners(wallstick.fake.character)
 
 	local simulationConnection = RunService.PreSimulation:Connect(function(dt)
+		if wallstick.fake.rootPart.Position.Y <= workspace.FallenPartsDestroyHeight then
+			outOfBounds = true
+		end
+
+		if outOfBounds then
+			local planet = findNearestPlanet()
+			if planet then
+				local direction = (planet.Position - hrp.Position).Unit
+				hrp.AssemblyLinearVelocity = direction * Config.OUT_OF_BOUNDS_SPEED
+			end
+			wallstick:setEnabled(false)
+			return
+		end
+
 		if not wallstick:isEnabled() then
 			return
 		end
@@ -179,7 +220,7 @@ local function onCharacterAdded(character: Model)
 			wallstick:setAndPivot(stickPart, stickNormal, result.Position)
 			fallTime = 0
 		else
-			if humanoid:GetState() == Enum.HumanoidStateType.Freefall then
+			if wallstick.fake.humanoid:GetState() == Enum.HumanoidStateType.Freefall then
 				fallTime += dt
 
 				if fallTime >= Config.RESPAWN_TIME then
@@ -191,12 +232,7 @@ local function onCharacterAdded(character: Model)
 					end
 					fallTime = 0
 				elseif fallTime >= Config.OUT_OF_BOUNDS_TIME then
-					local planet = findNearestPlanet()
-					if planet then
-						local direction = (planet.Position - hrp.Position).Unit
-						local speed = hrp.AssemblyLinearVelocity.Magnitude
-						hrp.AssemblyLinearVelocity = direction * speed
-					end
+					outOfBounds = true
 				end
 			else
 				fallTime = 0
@@ -206,7 +242,9 @@ local function onCharacterAdded(character: Model)
 
 	humanoid.Died:Wait()
 	simulationConnection:Disconnect()
-	touchedConnection:Disconnect()
+	for _, con in ipairs(touchedConnections) do
+		con:Disconnect()
+	end
 	cleanupDoubleJump()
 	wallstick:Destroy()
 end

--- a/src/server/GravityManager.luau
+++ b/src/server/GravityManager.luau
@@ -14,7 +14,11 @@ local controllers: { [Player]: GravityController.GravityController } = {}
 local GravityManager = {}
 
 local function setupCharacter(player: Player, character: Model)
-	controllers[player] = GravityController.new(character, Planets)
+	local controller = GravityController.new(character, Planets)
+	if not controller then
+		return
+	end
+	controllers[player] = controller
 	local humanoid = character:WaitForChild("Humanoid")
 	humanoid.Died:Connect(function()
 		local ctrl = controllers[player]
@@ -48,11 +52,9 @@ for _, player in ipairs(Players:GetPlayers()) do
 	onPlayerAdded(player)
 end
 
-
 RunService.Heartbeat:Connect(function(dt)
 	for _, controller in pairs(controllers) do
 		controller:update(dt)
-
 	end
 end)
 

--- a/src/server/PlayerScripts/GravityCameraModifier.luau
+++ b/src/server/PlayerScripts/GravityCameraModifier.luau
@@ -73,6 +73,9 @@ return function(PlayerModule: any)
 	end
 
 	local currentRotationType = UserGameSettings.RotationType
+	UserGameSettings:GetPropertyChangedSignal("RotationType"):Connect(function()
+		currentRotationType = UserGameSettings.RotationType
+	end)
 	local unmodifiedSetRotationTypeOverride = cameraUtils.setRotationTypeOverride
 	function cameraUtils.setRotationTypeOverride(...)
 		unmodifiedSetRotationTypeOverride(...)
@@ -89,19 +92,6 @@ return function(PlayerModule: any)
 
 	------------
 	local poppercam = require(PlayerModule.CameraModule.Poppercam) :: any
-	local zoomController = require(PlayerModule.CameraModule.ZoomController) :: any
-
-	function poppercam:Update(
-		renderDt: number,
-		desiredCameraCFrame: CFrame,
-		desiredCameraFocus: CFrame,
-		_cameraController: any
-	)
-		local rotatedFocus = desiredCameraFocus * (desiredCameraCFrame - desiredCameraCFrame.Position)
-		local extrapolation = self.focusExtrapolator:Step(renderDt, rotatedFocus)
-		local zoom = zoomController.Update(renderDt, rotatedFocus, extrapolation)
-		return rotatedFocus * CFrame.new(0, 0, zoom), desiredCameraFocus
-	end
 
 	------------
 	local baseCamera = require(PlayerModule.CameraModule.BaseCamera) :: any

--- a/src/shared/GravityController.luau
+++ b/src/shared/GravityController.luau
@@ -12,21 +12,23 @@ export type GravityController = {
 	fallTime: number,
 	prevDistance: number?,
 	outPlanet: BasePart?,
-
 }
 
 local GravityController = {}
 GravityController.__index = GravityController
 
-function GravityController.new(character: Model, planetsFolder: Folder): GravityController
+function GravityController.new(character: Model, planetsFolder: Folder): GravityController?
 	local self = setmetatable({}, GravityController)
 
 	self.planetsFolder = planetsFolder
-	self.root = character:WaitForChild("HumanoidRootPart", 5)
-	self.humanoid = character:WaitForChild("Humanoid", 5)
 
-	assert(self.root and self.humanoid, "GravityController: character missing required parts")
+	self.root = character:FindFirstChild("HumanoidRootPart") or character:WaitForChild("HumanoidRootPart", 10)
+	self.humanoid = character:FindFirstChild("Humanoid") or character:WaitForChild("Humanoid", 10)
 
+	if not (self.root and self.humanoid) then
+		warn("GravityController: character missing required parts")
+		return nil :: any
+	end
 
 	local attachment = self.root:FindFirstChild("RootAttachment")
 	if not attachment then
@@ -34,7 +36,6 @@ function GravityController.new(character: Model, planetsFolder: Folder): Gravity
 		attachment.Name = "RootAttachment"
 		attachment.Parent = self.root
 	end
-
 
 	local force = Instance.new("VectorForce")
 	force.Attachment0 = attachment
@@ -52,7 +53,6 @@ function GravityController.new(character: Model, planetsFolder: Folder): Gravity
 	orient.Enabled = false
 	orient.Parent = self.root
 	self.orientation = orient
-
 
 	self.fallTime = 0
 	self.prevDistance = nil
@@ -84,10 +84,7 @@ local function findNearestPlanet(planets: Folder, position: Vector3)
 	return closest
 end
 
-
 function GravityController:update(dt: number)
-
-
 	if self.humanoid:GetState() ~= Enum.HumanoidStateType.Freefall then
 		if self.force.Enabled then
 			self.force.Enabled = false
@@ -133,8 +130,7 @@ function GravityController:update(dt: number)
 	if self.fallTime >= Config.OUT_OF_BOUNDS_TIME or (distance and distance > Config.OUT_OF_BOUNDS_DISTANCE) then
 		if planet then
 			local dir = (planet.Position - self.root.Position).Unit
-			local speed = self.root.AssemblyLinearVelocity.Magnitude
-			self.root.AssemblyLinearVelocity = dir * speed
+			self.root.AssemblyLinearVelocity = dir * Config.OUT_OF_BOUNDS_SPEED
 			self.force.Enabled = false
 			self.force.Force = Vector3.zero
 			self.orientation.Enabled = false

--- a/src/shared/WallstickConfig.luau
+++ b/src/shared/WallstickConfig.luau
@@ -8,8 +8,9 @@ local Config = {
 	PULL_SEARCH_RADIUS = 50, -- radius to search for a surface when pulling
 	PLANET_PULL_TIME = 5, -- seconds before pulling to nearest planet
 	RESPAWN_TIME = 7, -- seconds before teleporting to SpawnLocation
-	OUT_OF_BOUNDS_TIME = 4.5, -- seconds in freefall before redirecting to a planet
+	OUT_OF_BOUNDS_TIME = 5, -- seconds in freefall before redirecting to a planet
 	OUT_OF_BOUNDS_DISTANCE = 1000, -- studs from origin considered out of bounds
+	OUT_OF_BOUNDS_SPEED = 100, -- velocity magnitude when redirecting to planet
 	PLANET_ORBIT_MULTIPLIER = 2.2, -- multiplier for planet orbit radius based on size
 	PLANET_GRAVITY = 100, -- strength of planet gravitational pull
 }


### PR DESCRIPTION
## Summary
- avoid crashing GravityController when character spawns without parts
- search for planets inside the `Planets` folder
- drive player back toward a planet when out of bounds
- add configurable out-of-bounds speed
- remove custom Poppercam update override

## Testing
- `./stylua src`
- `selene src` *(fails: Could not collect standard library)*

------
https://chatgpt.com/codex/tasks/task_e_687581a0e1f08325a3229b683b3eece2