### PR TITLE
Improve movement math and planet radius checks

### DIFF
--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -40,7 +40,8 @@ function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vec
 	local _, _, _, r00, r01, r02, _, r11, r12, _, _, r22 = cameraCF:GetComponents()
 
 	local c, s
-	local q = math.sign(r11)
+	-- default to positive when r11 is 0 to avoid dropping horizontal input
+	local q = if r11 >= 0 then 1 else -1
 
 	if r12 < 1 and r12 > -1 then
 		c = r22
@@ -51,6 +52,10 @@ function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vec
 	end
 
 	local norm = math.sqrt(c * c + s * s)
+	if norm < 1e-6 then
+		return Vector3.zero
+	end
+
 	local x = (c * move.X * q + s * move.Z) / norm
 	local z = (c * move.Z - s * move.X * q) / norm
 

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -96,14 +96,16 @@ local function onCharacterAdded(character: Model)
 		local closestDist = math.huge
 		local pos = hrp.Position
 
-		for _, planet in ipairs(planets) do
-			local dist = (planet.Position - pos).Magnitude
-			local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
-			if dist <= radius and dist < closestDist then
-				closest = planet
-				closestDist = dist
-			end
-		end
+               for _, planet in ipairs(planets) do
+                       local dist = (planet.Position - pos).Magnitude
+                       local radius = math.max(planet.Size.X, planet.Size.Y, planet.Size.Z)
+                               * 0.5
+                               * Config.PLANET_ORBIT_MULTIPLIER
+                       if dist <= radius and dist < closestDist then
+                               closest = planet
+                               closestDist = dist
+                       end
+               end
 
 		return closest
 	end

--- a/src/shared/GravityController.luau
+++ b/src/shared/GravityController.luau
@@ -63,6 +63,10 @@ function GravityController:destroy()
 	self.orientation:Destroy()
 end
 
+local function planetRadius(planet: BasePart): number
+	return math.max(planet.Size.X, planet.Size.Y, planet.Size.Z) / 2
+end
+
 local function findNearestPlanet(planets: Folder, position: Vector3)
 	local closest
 	local closestDist = math.huge
@@ -70,7 +74,7 @@ local function findNearestPlanet(planets: Folder, position: Vector3)
 	for _, planet in ipairs(planets:GetChildren()) do
 		if planet:IsA("BasePart") and planet.Name:sub(1, 6) == "Planet" then
 			local dist = (planet.Position - position).Magnitude
-			local radius = planet.Size.Magnitude * Config.PLANET_ORBIT_MULTIPLIER
+			local radius = planetRadius(planet) * Config.PLANET_ORBIT_MULTIPLIER
 			if dist <= radius and dist < closestDist then
 				closest = planet
 				closestDist = dist
@@ -115,7 +119,7 @@ function GravityController:update(dt: number)
 	if self.fallTime >= Config.OUT_OF_BOUNDS_TIME or (distance and distance > Config.OUT_OF_BOUNDS_DISTANCE) then
 		if planet then
 			local dir = (planet.Position - self.root.Position).Unit
-			local radius = planet.Size.Magnitude / 2
+			local radius = planetRadius(planet)
 			local target = planet.Position + dir * (radius + Config.STICK_RANGE)
 			self.humanoid:ChangeState(Enum.HumanoidStateType.Jumping)
 			self.root.AssemblyLinearVelocity = Vector3.zero


### PR DESCRIPTION
## Summary
- adjust camera movement math to avoid zero division and ambiguous sign
- use more accurate radius calculations for planets in gravity controller
- update client lookups for nearest planet to match new radius logic

## Testing
- `stylua src/client/Wallstick/GravityCamera.luau src/client/clientEntry.client.luau src/shared/GravityController.luau`

------
https://chatgpt.com/codex/tasks/task_e_6876bc48ac808325a3f52c669da84231