### PR TITLE
Implement camera spin smoothing

### DIFF
--- a/src/client/Wallstick/GravityCamera.luau
+++ b/src/client/Wallstick/GravityCamera.luau
@@ -44,8 +44,48 @@ function GravityCamera.getRotationType(): Enum.RotationType
 	return cameraModuleObject:GetRotationType()
 end
 
-function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?): Vector3
-	return controlModuleObject:GetMoveVector()
+function GravityCamera.getMoveVector(cameraCF: CFrame, inputMove: Vector3?, scale: number?): Vector3
+	local move = inputMove or controlModuleObject:GetMoveVector()
+
+	if move.Magnitude > 1e-6 then
+		local humanoid = localPlayer.Character and localPlayer.Character:FindFirstChild("Humanoid")
+		if humanoid then
+			move = move.Unit * humanoid.WalkSpeed
+		else
+			move = move.Unit
+		end
+	end
+
+	local _, _, _, r00, r01, r02, _, r11, r12, _, _, r22 = cameraCF:GetComponents()
+	local c, s
+	local q = if r11 >= 0 then 1 else -1
+
+	if r12 < 1 and r12 > -1 then
+		c = r22
+		s = r02
+	else
+		c = r00
+		s = -r01 * math.sign(r12)
+	end
+
+	local norm = math.sqrt(c * c + s * s)
+	if norm < 1e-6 then
+		return move
+	end
+
+	local x = (c * move.X * q + s * move.Z) / norm
+	local z = (c * move.Z - s * move.X * q) / norm
+	local result = Vector3.new(x, 0, z)
+
+	if scale then
+		result *= scale
+	end
+
+	return result
+end
+
+function GravityCamera.getTwistCFrame(): CFrame
+	return cameraModuleObject:GetTwistCFrame()
 end
 
 return GravityCamera

--- a/src/client/Wallstick/GravityCameraModifier.luau
+++ b/src/client/Wallstick/GravityCameraModifier.luau
@@ -4,7 +4,9 @@ local function patchCameraModule(playerModuleObject: any)
 	print("[Modifier] GravityCameraModifier running...")
 
 	local cameraModule = playerModuleObject:GetCameras()
+	local Camera = workspace.CurrentCamera
 	local transitionRate: number = 1
+	local smoothedTheta: number = 0
 
 	local upCFrame: CFrame = CFrame.identity
 	local upVector: Vector3 = upCFrame.YVector
@@ -37,6 +39,7 @@ local function patchCameraModule(playerModuleObject: any)
 
 	local function calculateSpinStep(_dt: number, inVehicle: boolean)
 		local theta = 0
+
 		if not inVehicle and spinPart == prevSpinPart then
 			local rotation = spinPart.CFrame.Rotation
 			local prevRotation = prevSpinCFrame.Rotation
@@ -48,19 +51,30 @@ local function patchCameraModule(playerModuleObject: any)
 			theta = math.sign(deltaAxis:Dot(spinAxis)) * twistTheta
 		end
 
-		-- Anti-beyblade
 		if not theta or theta ~= theta or math.abs(theta) > math.pi then
 			theta = 0
 			warn("[Spin Debug] Invalid theta detected, reset to 0")
 		end
 
-		theta = math.clamp(theta, -math.pi / 2, math.pi / 2)
-		print("[Spin Debug] theta (deg):", math.deg(theta))
+		-- Optional: force reset if large snap
+		if math.abs(theta - smoothedTheta) > math.rad(180) then
+			print("[Spin Debug] Snap correction applied")
+			smoothedTheta = theta
+		end
 
-		-- Optional smoothing
-		-- smoothedTheta = smoothedTheta + (theta - smoothedTheta) * math.clamp(_dt * 5, 0, 1)
+		-- Smooth theta change to prevent spin
+		smoothedTheta = smoothedTheta + (theta - smoothedTheta) * math.clamp(_dt * 10, 0, 1)
 
-		twistCFrame = CFrame.fromEulerAnglesYXZ(0, theta, 0)
+		print("[SpinActive] Updating spin with theta =", math.deg(theta), "smoothed =", math.deg(smoothedTheta))
+
+		twistCFrame = CFrame.fromEulerAnglesYXZ(0, smoothedTheta, 0)
+
+		-- Base forward-facing camera with current position + look vector
+		local baseCF =
+			CFrame.lookAt(Camera.CFrame.Position, Camera.CFrame.Position + Camera.CFrame.LookVector, upVector)
+		Camera.CFrame = baseCF * CFrame.Angles(0, smoothedTheta, 0)
+		print("[CamPos]", Camera.CFrame.Position, "[Look]", Camera.CFrame.LookVector)
+
 		prevSpinPart = spinPart
 		prevSpinCFrame = spinPart.CFrame
 	end
@@ -87,6 +101,8 @@ local function patchCameraModule(playerModuleObject: any)
 	end
 	function cameraModule:SetSpinPart(part: BasePart)
 		spinPart = part
+		prevSpinPart = part
+		prevSpinCFrame = part.CFrame
 	end
 	function cameraModule:SetTransitionRate(rate: number)
 		transitionRate = rate
@@ -97,14 +113,16 @@ local function patchCameraModule(playerModuleObject: any)
 	function cameraModule:GetRotationType()
 		return Enum.RotationType.CameraRelative
 	end
--- function cameraModule:GetTwistCFrame()
---	return twistCFrame
---	end
+	function cameraModule:GetTwistCFrame()
+		return twistCFrame
+	end
+
 	local originalUpdate = cameraModule.Update
 	function cameraModule:Update(dt: number)
 		local result = originalUpdate(self, dt)
 		calculateUpStep(dt)
 		calculateSpinStep(dt, self:ShouldUseVehicleCamera())
+
 		return result
 	end
 

--- a/src/client/Wallstick/init.luau
+++ b/src/client/Wallstick/init.luau
@@ -354,6 +354,9 @@ function WallstickClass._stepRenderCharacter(self: Wallstick, _dt: number)
 	then
 		local right = GravityCamera.getMoveVector(geometryCameraCF, Vector3.xAxis)
 		local rotation = CFrame.fromMatrix(Vector3.zero, right, Vector3.yAxis)
+		if GravityCamera.getTwistCFrame then
+			rotation *= GravityCamera.getTwistCFrame()
+		end
 		self.fake.alignOrientation.CFrame = rotation
 		self.fake.alignOrientation.Enabled = true
 	else

--- a/src/client/clientEntry.client.luau
+++ b/src/client/clientEntry.client.luau
@@ -129,6 +129,15 @@ local function onCharacterAdded(character: Model)
 			local stickNormal = stickPart.CFrame:VectorToObjectSpace(result.Normal)
 
 			wallstick:setAndPivot(stickPart, stickNormal, result.Position)
+		else
+			if humanoid:GetState() == Enum.HumanoidStateType.Freefall then
+				local planetHit = findNearestSurface(Config.STICK_RANGE, true)
+				if planetHit then
+					local planetPart = (planetHit.Instance :: BasePart).AssemblyRootPart
+					local planetNormal = planetPart.CFrame:VectorToObjectSpace(planetHit.Normal)
+					wallstick:setAndPivot(planetPart, planetNormal, planetHit.Position)
+				end
+			end
 		end
 	end)
 

--- a/src/shared/GravityController.luau
+++ b/src/shared/GravityController.luau
@@ -241,6 +241,10 @@ function GravityController:update(dt: number)
 		self.force.Enabled = true
 
 		local up = -dir
+		local moveVector = self.humanoid.MoveDirection
+		if moveVector.Magnitude > 0.01 then
+			self.root.CFrame = CFrame.lookAt(rootPos, rootPos + moveVector, up)
+		end
 		local look = self.root.CFrame.LookVector
 		self.orientation.CFrame = CFrame.lookAt(rootPos, rootPos + look, up)
 		self.orientation.Enabled = true
@@ -250,6 +254,10 @@ function GravityController:update(dt: number)
 		self.force.Enabled = true
 
 		local up = -direction
+		local moveVector = self.humanoid.MoveDirection
+		if moveVector.Magnitude > 0.01 then
+			self.root.CFrame = CFrame.lookAt(rootPos, rootPos + moveVector, up)
+		end
 		local look = self.root.CFrame.LookVector
 		self.orientation.CFrame = CFrame.lookAt(rootPos, rootPos + look, up)
 		self.orientation.Enabled = true


### PR DESCRIPTION
## Summary
- adjust camera modifier to prevent abrupt spin
- expose twist CFrame for external use
- integrate twist rotation into character alignment
- orient characters based on movement
- scale move vector by WalkSpeed
- auto-stick to nearby planet when falling
- fix compounding camera twist

## Testing
- `stylua src/client/Wallstick/GravityCameraModifier.luau src/client/Wallstick/GravityCamera.luau src/shared/GravityController.luau src/client/clientEntry.client.luau`


------
https://chatgpt.com/codex/tasks/task_e_687adfb53abc8325952ca50ecf9af224