### PR TITLE
Fix camera twist accumulation

### DIFF
--- a/src/client/Wallstick/GravityCameraModifier.luau
+++ b/src/client/Wallstick/GravityCameraModifier.luau
@@ -63,9 +63,15 @@ local function patchCameraModule(playerModuleObject: any)
 
 		-- Smooth theta change to prevent spin
 		smoothedTheta = smoothedTheta + (theta - smoothedTheta) * math.clamp(_dt * 10, 0, 1)
-		print("[Spin Debug] theta (deg):", math.deg(smoothedTheta))
+		print("[SpinActive] Updating spin with theta =", math.deg(theta), "smoothed =", math.deg(smoothedTheta))
 
-		twistCFrame = CFrame.fromEulerAnglesYXZ(0, smoothedTheta, 0)
+		local camera = workspace.CurrentCamera
+		local baseCF =
+			CFrame.lookAt(camera.CFrame.Position, camera.CFrame.Position + camera.CFrame.LookVector, upVector)
+		camera.CFrame = baseCF * CFrame.Angles(0, smoothedTheta, 0)
+		twistCFrame = CFrame.Angles(0, smoothedTheta, 0)
+		print("[CamPos]", camera.CFrame.Position, "[Look]", camera.CFrame.LookVector)
+
 		prevSpinPart = spinPart
 		prevSpinCFrame = spinPart.CFrame
 	end
@@ -113,12 +119,6 @@ local function patchCameraModule(playerModuleObject: any)
 		local result = originalUpdate(self, dt)
 		calculateUpStep(dt)
 		calculateSpinStep(dt, self:ShouldUseVehicleCamera())
-
-		local camera = workspace.CurrentCamera
-		local baseCF =
-			CFrame.lookAt(camera.CFrame.Position, camera.CFrame.Position + camera.CFrame.LookVector, upVector)
-		camera.CFrame = twistCFrame * baseCF
-
 		return result
 	end
 


### PR DESCRIPTION
## Summary
- update camera spin logic to prevent compound rotation
- move camera orientation update to `calculateSpinStep`
- remove orientation calculation from `Update`

## Testing
- `stylua src/client/Wallstick/GravityCameraModifier.luau`

------
https://chatgpt.com/codex/tasks/task_e_687aef36dc208325b60ece6eb59324ee